### PR TITLE
Add Not falling to door

### DIFF
--- a/36461_metafix_eledoor.cos
+++ b/36461_metafix_eledoor.cos
@@ -111,10 +111,6 @@ link va01 va02 100
 *
 
 *
-* ====== SCRIPTS ======
-*
-
-*
 ** DOOR SCRIPT
 
 ** BUG: If one of the doors is in the inventory and offscreen, this throws an error.

--- a/36461_metafix_eledoor.cos
+++ b/36461_metafix_eledoor.cos
@@ -111,6 +111,10 @@ link va01 va02 100
 *
 
 *
+* ====== SCRIPTS ======
+*
+
+*
 ** DOOR SCRIPT
 
 ** BUG: If one of the doors is in the inventory and offscreen, this throws an error.
@@ -127,12 +131,12 @@ scrp 2 2 36461 1
 	enum 2 2 36461
 		doif targ ne va01
 			doif ov01 eq va00
-				doif carr eq null
+				doif carr eq null and fall eq 0
 				else
 					doif targ ne null
 						snde "buzz"
 						rtar 1 2 10
-						mesg wrt+ targ 126 "Destination is being carried" ownr 0
+						mesg wrt+ targ 126 "Destination is being carried or is falling" ownr 0
 						stop
 					endi
 				endi


### PR DESCRIPTION
Because we don't want creatures teleporting in mid-air